### PR TITLE
Additional Optimizations

### DIFF
--- a/examples/conflux_miniapp.cpp
+++ b/examples/conflux_miniapp.cpp
@@ -82,16 +82,13 @@ int main(int argc, char *argv[]) {
 
     for (int i = 0; i < n_rep; ++i) {
         PC();
+        // reinitialize the matrix
+        params.InitMatrix();
         conflux::LU_rep<double>(params.matrix.data(), 
                                C.data(), 
                                Perm.data(), 
                                params, 
                                MPI_COMM_WORLD);  
-        // print the profiler data
-        if (rank == 0) {
-            PP();
-        }
-
 #ifdef CONFLUX_WITH_VALIDATION
         if (rank == 0) {
             auto M = params.M;
@@ -141,6 +138,11 @@ int main(int argc, char *argv[]) {
         }
 #endif
     }
+    // print the profiler data
+    if (rank == 0) {
+        PP();
+    }
+
 
     // if not MPI_COMM_WORLD, deallocate it
     if (newP < P) {

--- a/src/conflux/lu/conflux_opt.hpp
+++ b/src/conflux/lu/conflux_opt.hpp
@@ -481,7 +481,7 @@ void LU_rep(T *A,
     std::tie(pi, pj, pk) = p2X(lu_comm, rank);
 
     // Create buffers
-    std::vector<T> A00Buff(v * v + v);
+    std::vector<T> A00Buff(v * v);
 
     // A10 => M
     // A01 => N
@@ -732,7 +732,7 @@ if (debug_level > 1) {
                 }
             }
 #endif
-            MPI_Request A00_req[6];
+            MPI_Request A00_req[2];
             int n_A00_reqs = 0;
             if (pj == k % Py && pk == layrK) {
                 auto min_perm_size = std::min(N - k*v, v);
@@ -925,18 +925,6 @@ if (debug_level > 1) {
             // the one who entered this is the root
             auto root = X2p(jk_comm, k % Py, layrK);
 
-            /*
-            PE(step1_A00Buff_bcast);
-            if (rank == root) {
-                std::copy_n(&pivotIndsBuff[k*v], v, &A00Buff[v*v]);
-            }
-            MPI_Bcast(&A00Buff[0], v*v+v, MPI_DOUBLE, root, jk_comm);
-            if (rank != root) {
-                std::copy_n(&A00Buff[v*v], v, &pivotIndsBuff[k*v]);
-            }
-            PL();
-            */
-
             // # Sending A00Buff:
             /*
             PE(step1_A00Buff_bcast);
@@ -951,16 +939,11 @@ if (debug_level > 1) {
             MPI_Ibcast(&pivotIndsBuff[k * v], v, MPI_DOUBLE, root, jk_comm, &pivotIndsBuff_bcast_req);
             PL();
 
-            // # Sending pivots:
+            // PE(step1_barrier);
+            // MPI_Barrier(lu_comm);
+            // PL();
+
             PE(step1_curPivots);
-            /*
-            if (raNK !=
-            for (int pj_rcv = 0; pj_rcv < Py; ++pj_rcv) {
-                for (int pk_rcv = 0; pk_rcv < Pz; ++pk_rcv) {
-                    MPI_Irecv
-                }
-            }
-            */
             MPI_Bcast(&curPivots[0], 2*v+1, MPI_INT, root, jk_comm);
             PL();
 

--- a/src/conflux/lu/lu_params.hpp
+++ b/src/conflux/lu/lu_params.hpp
@@ -50,6 +50,8 @@ class lu_params {
         tA11y = (int)(std::ceil((double)Nt / Py));
     }
 
+public:
+
     void InitMatrix() {
         if (N == 16 && M == 16) {
             matrix = {
@@ -145,7 +147,6 @@ class lu_params {
         }
     }
 
-   public:
     int M, N, P;
     // Px refers to rows
     // Py refers to cols


### PR DESCRIPTION
This PR brings the following improvements:
- [bugfix] Negative message size in MPI fixed
- [bugfix] Missing MPI_Irecv in tournament pivoting fixed
- [bugfix] Fixed n_reqs in tournament pivoting when Px not a power of 2
- [smallfix] The matrix reinitialized in each step, to get more consistent benchmarking results.
- [optimization] Removed a redundant A00 broadcast after pivoting
- [optimization] Removed the broadcast of `curPivOrder`, which is now sent with `curPivots`
- [optimization] Further optimizations