### PR TITLE
Fix Initial Bcast Size problem

### DIFF
--- a/src/conflux/cholesky/Cholesky.cpp
+++ b/src/conflux/cholesky/Cholesky.cpp
@@ -548,7 +548,7 @@ void conflux::parallelCholesky()
     // in debug mode, write the matrix back into a file in every round
     #ifdef DEBUG
     std::stringstream tmp;
-    tmp << "../data/output_" << prop->N << ".bin";
+    tmp << "data/output_" << prop->N << ".bin";
     io->openFile(tmp.str());
     #endif //DEBUG
     /********************** START OF THE FACTORIZATION ***********************/

--- a/src/conflux/cholesky/Processor.cpp
+++ b/src/conflux/cholesky/Processor.cpp
@@ -145,13 +145,13 @@ void conflux::Processor::updateBcastComm(uint32_t remTiles)
         return;
     }
 
-        this->isWorldBroadcast = false;
-        m_curIdx++;
-        bcastComm = m_bcastComms[m_curIdx];
-        inBcastComm = m_inCurrentBcastComm[m_curIdx];
-        if (inBcastComm) {
-            //std::cout << rank << " in round " << m_prop->Kappa - 2 - remTiles << std::endl;
-        }
+    this->isWorldBroadcast = false;
+    m_curIdx++;
+    bcastComm = m_bcastComms[m_curIdx];
+    inBcastComm = m_inCurrentBcastComm[m_curIdx];
+    if (inBcastComm) {
+        //std::cout << rank << " in round " << m_prop->Kappa - 2 - remTiles << std::endl;
+    }
 }
 
 /**
@@ -189,9 +189,8 @@ void conflux::Processor::initializeBroadcastComms()
     }  
 
     else {
-        maxBroadcastSize = 1 << (uint64_t)ceil(log2(m_prop->P));
+        maxBroadcastSize = 1 << (uint64_t)ceil(log2(m_prop->Kappa - 2));
         if (maxBroadcastSize >= m_prop->P) {
-            //if (rank == 0) std::cout << "Second branch" << std::endl;
             m_inCurrentBcastComm.push_back(true);
             m_bcastComms.push_back(MPI_COMM_WORLD);
 
@@ -202,11 +201,9 @@ void conflux::Processor::initializeBroadcastComms()
             m_bcastSizes.push_back(m_prop->P);
             maxBroadcastSize /= 2;
             this->isWorldBroadcast = true;
-
         }
 
         else {
-            //if (rank == 0) std::cout << "Third branch" << std::endl;
             this->isWorldBroadcast = false;
             createNewComm(maxBroadcastSize);
         }


### PR DESCRIPTION
This PR fixes the initial broadcast size that was accidentally set to P instead of to the next larger power of two from the limiting factor. This leads to a minor performance increase in large P small N scenarios.